### PR TITLE
attempting forced refresh with key

### DIFF
--- a/src/views/DataMap.vue
+++ b/src/views/DataMap.vue
@@ -5,6 +5,7 @@
     it myself. Nothing to really see here yet other than the map showing up.
   </p>
   <DataMapContainer
+    :key="dataMapKey"
     :fills="{
       HIGH: '#afafaf',
       LOW: '#123456',
@@ -17,12 +18,19 @@
 </template>
 
 <script>
+import { v4 as uuidv4 } from "uuid";
 import DataMapContainer from "@/components/DataMapContainer.vue";
 
 export default {
   name: "Movies",
   components: {
     DataMapContainer,
+  },
+  computed: {
+    // This should force a new key to be made for the map, causing refresh.
+    dataMapKey() {
+      return uuidv4();
+    },
   },
 };
 </script>


### PR DESCRIPTION
By using a uuid key, this should queue vue into refreshing the component resulting in no duplicate maps on the page.