### PR TITLE
simplified add_request mutation and use udpated api structure for books

### DIFF
--- a/src/components/TheApiVisualizer.vue
+++ b/src/components/TheApiVisualizer.vue
@@ -14,7 +14,7 @@
           aria-expanded="true"
           aria-controls="collapseOne"
         >
-          {{ request.url }} ...responded with {{ request.response.status }}
+          {{ request.url }} ...responded with {{ request.status }}
         </button>
       </h2>
       <div
@@ -24,13 +24,12 @@
         data-bs-parent="#apiRequests"
       >
         <div class="accordion-body">
-          <pre v-if="request.payload">{{
-            JSON.stringify(request.payload, undefined, 2)
-          }}</pre>
+          <pre v-if="request.payload">
+            {{ JSON.stringify(request.payload, undefined, 2) }}
+          </pre>
           <pre>
-              {{ JSON.stringify(request.response.body, undefined, 2) }}
-            </pre
-          >
+            {{ JSON.stringify(request.response, undefined, 2) }}
+          </pre>
         </div>
       </div>
     </div>

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -14,12 +14,10 @@ const loadBooks = ({ commit }) => {
   return HttpService.get("books", (status, response) => {
     commit("ADD_API_REQUEST", {
       url: "GET /api/v1/books",
-      response: {
-        data: response,
-        status,
-      },
+      response,
+      status,
     });
-    commit("SET_BOOKS", response);
+    commit("SET_BOOKS", response.data || response);
     commit("STOP_LOADING");
   });
 };
@@ -37,7 +35,8 @@ const loadMovies = ({ commit }, movieTitle) => {
   return HttpService.get(`movies?title=${movieTitle}`, (status, response) => {
     commit("ADD_API_REQUEST", {
       url: `GET /api/v1/movies?title=${movieTitle}`,
-      response: { data: response, status },
+      response,
+      status,
     });
     commit("SET_MOVIES", response.data);
     commit("STOP_LOADING");
@@ -49,7 +48,8 @@ const loadRepos = ({ commit }) => {
   return HttpService.get(`github_repos`, (status, response) => {
     commit("ADD_API_REQUEST", {
       url: "GET /api/v1/github_repos",
-      response: { data: response, status },
+      response,
+      status,
     });
     commit("SET_REPOS", response.data);
     commit("SET_CATEGORIES", [
@@ -69,7 +69,8 @@ const login = ({ commit }, { username, password, redirectTo = "/" }) => {
     commit("STOP_LOADING");
     commit("ADD_API_REQUEST", {
       url: "POST /api/v1/login",
-      response: { data: response, status },
+      response,
+      status,
     });
 
     if (response.data.token) {
@@ -83,7 +84,8 @@ const removeFavoriteBook = ({ commit }, book) => {
   HttpService.delete(`/user_books/${book.id}`, (status, response) => {
     commit("ADD_API_REQUEST", {
       url: `DELETE /api/v1/user_books/${book.id}`,
-      response: { data: response, status },
+      response,
+      status,
     });
     commit("DESTROY_FAVORITE_BOOK", book);
   });
@@ -93,7 +95,8 @@ const setFavoriteBook = ({ commit }, book) => {
   HttpService.post("/user_books", { book_id: book.id }, (status, response) => {
     commit("ADD_API_REQUEST", {
       url: "POST /api/v1/user_books",
-      response: { data: response, status },
+      response,
+      status,
     });
     commit("CREATE_FAVORITE_BOOK", book);
   });

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -68,10 +68,8 @@ const ADD_API_REQUEST = (state, request) => {
     {
       id: uuidv4(),
       url: request.url,
-      response: {
-        body: request.response.data,
-        status: request.response.status,
-      },
+      status: request.status,
+      response: request.response,
     },
     ...state.apiVisualizer.apiRequests,
   ];

--- a/tests/unit/store/actions.spec.js
+++ b/tests/unit/store/actions.spec.js
@@ -31,7 +31,7 @@ describe("actions", () => {
   describe("loadBooks", () => {
     beforeEach(() => {
       httpService.get.mockImplementation((_, callback) =>
-        callback(200, [{ title: "Go Blue" }])
+        callback(200, { data: [{ title: "Go Blue" }] })
       );
       actions.loadBooks({ commit });
     });
@@ -41,8 +41,9 @@ describe("actions", () => {
     });
     test("loadBooks calls commit with ADD_API_REQUEST", () => {
       expect(commit).toHaveBeenCalledWith("ADD_API_REQUEST", {
-        response: { data: [{ title: "Go Blue" }], status: 200 },
         url: "GET /api/v1/books",
+        response: { data: [{ title: "Go Blue" }] },
+        status: 200,
       });
     });
     test("loadBooks calls commit with SET_BOOKS", () => {


### PR DESCRIPTION
the api books controller is changing to using the data envelope in the response, this PR allows calls to old api and new to both work. I will change the line that allows this after backend is deployed.